### PR TITLE
Corrigindo o footer no mobile

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,6 @@
 <html>
 	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta content="https://bomdianao.com.br/" property="og:url">
     <meta property="og:description" content="Por favor não diga apenas &quot;bom dia&quot; no chat">
     <meta content="Bom dia não" property="og:title">

--- a/docs/style.css
+++ b/docs/style.css
@@ -41,6 +41,9 @@ footer {
     text-align: center;
     padding: 10px;
     font-size: 0.9rem;
+    position: fixed;
+    bottom: 0;
+    left:0;
 }
 
 .chat {
@@ -58,4 +61,10 @@ a {
     color: blue !important;
     text-decoration: none;
     font-weight: bold;
+}
+
+@media only screen and (max-width: 600px) {
+    footer {
+        padding: 5px;
+    }
 }


### PR DESCRIPTION
Resolves #3 

Este PR arruma o footer, para que ele não fique flutuando para cima e diminui o padding no mobile através de media queries.
O meta no html já ajuda ele a não ficar minúsculo no mobile também

Algumas screen shots:

Mobile
![image](https://user-images.githubusercontent.com/711732/95115105-51a1c600-071b-11eb-894f-d7bebab72b3b.png)

Desktop:
![image](https://user-images.githubusercontent.com/711732/95115173-6ed69480-071b-11eb-86c3-0a10086dcc6c.png)

Galsy S5
![image](https://user-images.githubusercontent.com/711732/95115208-7b5aed00-071b-11eb-9279-f0b2950a1cd0.png)

Iphone X
![image](https://user-images.githubusercontent.com/711732/95115238-857ceb80-071b-11eb-9b47-191ebbb0bf01.png)
